### PR TITLE
尝试修复服务器歌词时而出现的匹配不对的情况

### DIFF
--- a/core/music/play/LyricSave.java
+++ b/core/music/play/LyricSave.java
@@ -85,12 +85,33 @@ public class LyricSave {
         return false;
     }
 
+    /*
+     * 因为一些原因，直接 Map.get 会出现歌词匹配速度不太对的问题... 
+     * 本方法虽然没有原来的好看，但准度提高并且几乎不会影响服务器
+     */
+    public LyricItemObj findLrcObj(Map<Integer, LyricItemObj> map, int time) {
+        Set set = map.entrySet();
+        LyricItemObj latestObj = new LyricItemObj("", "");
+        for (Iterator iter = set.iterator(); iter.hasNext();) {
+            Map.Entry entry = (Map.Entry) iter.next();
+            int key = (int) entry.getKey();
+            if (time == key)
+                return (LyricItemObj) entry.getValue();
+            else if (time < key) {
+                return latestObj;
+            } else {
+                latestObj = (LyricItemObj) entry.getValue();
+            }
+        }
+        return latestObj;
+    }
+
     public boolean checkTime(int playNow, boolean ktv) {
         if (lyric == null)
             return false;
 
         boolean res = false;
-        LyricItemObj temp = lyric.get(playNow);
+        LyricItemObj temp = findLrcObj(lyric, playNow);
         if (temp != null) {
             now = temp;
             lly = now.lyric;


### PR DESCRIPTION
# 尝试修复服务器歌词时而出现的匹配不对的情况
## 前言
一般在本地测试的时候，歌词还是能匹配正确的，但一到真实环境，可能因为各种原因导致歌词匹配出问题，歌词没有及时刷新。
## 稳定性&是否解决问题
本 pull request 尝试修复此问题，并且已在本人的 [fork 版本](https://gitlab.com/wifi-left/mcbamboomusic) 中工作正常。
## 效率问题
经过测试，几乎不会影响效率，准度将会极大提高。