### PR TITLE
[Folia] 修复潜在的线程死锁

### DIFF
--- a/folia/src/main/java/com/coloryr/allmusic/server/side/folia/FunCore.java
+++ b/folia/src/main/java/com/coloryr/allmusic/server/side/folia/FunCore.java
@@ -19,10 +19,12 @@ public class FunCore {
                 rain = random.nextInt(rate) == (rate / 2);
             }
             if (rain) {
-                for (World item : Bukkit.getWorlds()) {
-                    item.setStorm(true);
-                }
-                AllMusic.side.bq(AllMusic.getMessage().fun.rain);
+                AllMusic.side.runTask(() -> {
+                    for (World item : Bukkit.getWorlds()) {
+                        item.setStorm(true);
+                    }
+                    AllMusic.side.bq(AllMusic.getMessage().fun.rain);
+                });
             }
         }
     }

--- a/folia/src/main/java/com/coloryr/allmusic/server/side/folia/SideFolia.java
+++ b/folia/src/main/java/com/coloryr/allmusic/server/side/folia/SideFolia.java
@@ -25,6 +25,7 @@ import org.bukkit.permissions.ServerOperator;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
 
 public class SideFolia extends BaseSide {
     @Override
@@ -413,21 +414,26 @@ public class SideFolia extends BaseSide {
     @Override
     public boolean onMusicAdd(Object obj, MusicObj music) {
         MusicAddEvent event = new MusicAddEvent(music, (CommandSender) obj);
-        ScheduledTask task = Bukkit.getGlobalRegionScheduler().run(AllMusicFolia.plugin, (scheduledTask) -> {
-            Bukkit.getPluginManager().callEvent(event);
-            if (!event.isCancel()) {
-                FunCore.addMusic();
-            }
-        });
-        while (task.getExecutionState() == ScheduledTask.ExecutionState.IDLE
-                || task.getExecutionState() == ScheduledTask.ExecutionState.RUNNING) {
-            try {
-                Thread.sleep(10);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+        boolean isGlobalTickThread = Bukkit.isGlobalTickThread();
+        if (!isGlobalTickThread) {
+            CompletableFuture<Boolean> future = new CompletableFuture<>();
+            Bukkit.getGlobalRegionScheduler().execute(AllMusicFolia.plugin, () -> {
+                Bukkit.getPluginManager().callEvent(event);
+                boolean isCancelled = event.isCancelled();
+                if (!isCancelled) {
+                    FunCore.addMusic();
+                }
+                future.complete(isCancelled);
+            });
+            return future.join();
         }
-        return event.isCancel();
+
+        Bukkit.getPluginManager().callEvent(event);
+        final boolean isCancelled = event.isCancelled();
+        if (!isCancelled) {
+            FunCore.addMusic();
+        }
+        return isCancelled;
     }
 
     private void send(Player players, ByteBuf data) {

--- a/folia/src/main/java/com/coloryr/allmusic/server/side/folia/SideFolia.java
+++ b/folia/src/main/java/com/coloryr/allmusic/server/side/folia/SideFolia.java
@@ -415,7 +415,7 @@ public class SideFolia extends BaseSide {
     public boolean onMusicAdd(Object obj, MusicObj music) {
         MusicAddEvent event = new MusicAddEvent(music, (CommandSender) obj);
         boolean isGlobalTickThread = Bukkit.isGlobalTickThread();
-        if (!isGlobalTickThread) {
+        if (!isGlobalTickThread && obj instanceof Player player && !Bukkit.isOwnedByCurrentRegion(player)) {
             CompletableFuture<Boolean> future = new CompletableFuture<>();
             Bukkit.getGlobalRegionScheduler().execute(AllMusicFolia.plugin, () -> {
                 Bukkit.getPluginManager().callEvent(event);

--- a/folia/src/main/java/com/coloryr/allmusic/server/side/folia/SideFolia.java
+++ b/folia/src/main/java/com/coloryr/allmusic/server/side/folia/SideFolia.java
@@ -414,20 +414,6 @@ public class SideFolia extends BaseSide {
     @Override
     public boolean onMusicAdd(Object obj, MusicObj music) {
         MusicAddEvent event = new MusicAddEvent(music, (CommandSender) obj);
-        boolean isGlobalTickThread = Bukkit.isGlobalTickThread();
-        if (!isGlobalTickThread && obj instanceof Player player && !Bukkit.isOwnedByCurrentRegion(player)) {
-            CompletableFuture<Boolean> future = new CompletableFuture<>();
-            Bukkit.getGlobalRegionScheduler().execute(AllMusicFolia.plugin, () -> {
-                Bukkit.getPluginManager().callEvent(event);
-                boolean isCancelled = event.isCancelled();
-                if (!isCancelled) {
-                    FunCore.addMusic();
-                }
-                future.complete(isCancelled);
-            });
-            return future.join();
-        }
-
         Bukkit.getPluginManager().callEvent(event);
         final boolean isCancelled = event.isCancelled();
         if (!isCancelled) {

--- a/folia/src/main/java/com/coloryr/allmusic/server/side/folia/event/MusicAddEvent.java
+++ b/folia/src/main/java/com/coloryr/allmusic/server/side/folia/event/MusicAddEvent.java
@@ -2,6 +2,7 @@ package com.coloryr.allmusic.server.side.folia.event;
 
 import com.coloryr.allmusic.server.core.objs.music.MusicObj;
 import org.bukkit.command.CommandSender;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
@@ -9,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * 音乐添加事件
  */
-public class MusicAddEvent extends Event {
+public class MusicAddEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     /**
      * 添加的音乐
@@ -29,10 +30,22 @@ public class MusicAddEvent extends Event {
         this.player = player;
     }
 
+    /**
+     * 事件是否被取消
+     * @return 是否被取消
+     * @deprecated 请使用 {@link #isCancelled()}
+     */
+    @Deprecated(since = "3.3.1")
     public boolean isCancel() {
         return cancel;
     }
 
+    /**
+     * 设置事件是否被取消
+     * @param cancel 是否取消事件
+     * @deprecated 请使用 {@link #setCancelled(boolean)}
+     */
+    @Deprecated(since = "3.3.1")
     public void setCancel(boolean cancel) {
         this.cancel = cancel;
     }
@@ -49,5 +62,15 @@ public class MusicAddEvent extends Event {
     @Override
     public HandlerList getHandlers() {
         return handlers;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
     }
 }


### PR DESCRIPTION
此 PR 修复了 Folia 服务端搜索歌曲时可能出现的死锁问题。
弃用 MusicAddEvent 中原有的 isCancel/setCancel 方法，实现Bukkit Cancellable接口使其更标准化

### 日志

https://mclo.gs/7SyVm6W

### 分析

Folia 在执行命令时可能会将其调度至 GlobalRegionScheduler, 原有的等待机制会在调度前后线程相同时造成死锁

### 解决方案

callEvent前先检查是否已经处于GlobalRegionThread，是则直接callEvent并返回，无需进行调度