### PR TITLE
修复一系列 Folia 相关问题

### DIFF
--- a/folia/src/main/java/com/coloryr/allmusic/server/side/folia/SideFolia.java
+++ b/folia/src/main/java/com/coloryr/allmusic/server/side/folia/SideFolia.java
@@ -168,32 +168,19 @@ public class SideFolia extends BaseSide {
     @Override
     public boolean onMusicPlay(SongInfoObj obj) {
         MusicPlayEvent event = new MusicPlayEvent(obj);
-        ScheduledTask task = Bukkit.getGlobalRegionScheduler().run(AllMusicFolia.plugin, (scheduledTask) -> {
-            Bukkit.getPluginManager().callEvent(event);
-            if (!event.isCancel()) {
-                FunCore.addMusic();
-            }
-        });
-        while (task.getExecutionState() == ScheduledTask.ExecutionState.IDLE
-                || task.getExecutionState() == ScheduledTask.ExecutionState.RUNNING) {
-            try {
-                Thread.sleep(10);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-        return event.isCancel();
-    }
-
-    @Override
-    public boolean onMusicAdd(Object obj, MusicObj music) {
-        MusicAddEvent event = new MusicAddEvent(music, (CommandSender) obj);
         Bukkit.getPluginManager().callEvent(event);
         final boolean isCancelled = event.isCancelled();
         if (!isCancelled) {
             FunCore.addMusic();
         }
         return isCancelled;
+    }
+
+    @Override
+    public boolean onMusicAdd(Object obj, MusicObj music) {
+        MusicAddEvent event = new MusicAddEvent(music, (CommandSender) obj);
+        Bukkit.getPluginManager().callEvent(event);
+        return event.isCancelled();
     }
 
     @Override

--- a/folia/src/main/java/com/coloryr/allmusic/server/side/folia/event/MusicPlayEvent.java
+++ b/folia/src/main/java/com/coloryr/allmusic/server/side/folia/event/MusicPlayEvent.java
@@ -1,6 +1,7 @@
 package com.coloryr.allmusic.server.side.folia.event;
 
 import com.coloryr.allmusic.server.core.objs.music.SongInfoObj;
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
@@ -8,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * 音乐播发事件
  */
-public class MusicPlayEvent extends Event {
+public class MusicPlayEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
     /**
      * 音乐内容
@@ -27,10 +28,12 @@ public class MusicPlayEvent extends Event {
         return music;
     }
 
+    @Deprecated(since = "3.4.5")
     public boolean isCancel() {
         return cancel;
     }
 
+    @Deprecated(since = "3.4.5")
     public void setCancel(boolean cancel) {
         this.cancel = cancel;
     }
@@ -39,5 +42,15 @@ public class MusicPlayEvent extends Event {
     @Override
     public HandlerList getHandlers() {
         return handlers;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancel;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancel = cancel;
     }
 }


### PR DESCRIPTION
1. 移除 `onMusicPlay` 的任务重新调度，会导致区域调度器无限等待自身
2. 弃用 MusicPlayEvent 中的 isCancel setCancel方法 实现 Cancellable 更规范
3. 移除 添加音乐时的天气变化检查 和 Bukkit 版本同步