### PR TITLE
命令补全问题以及部分功能的优化

### DIFF
--- a/core/command/CommandBan.java
+++ b/core/command/CommandBan.java
@@ -27,7 +27,7 @@ public class CommandBan extends ACommand {
 
     @Override
     public List<String> tab(Object player, String name, String[] args, int index) {
-        if (args.length == index || (args.length == index + 1 && args[index].isEmpty())) {
+        if (args.length == index || (args.length == index + 1 )) {
             List<String> list = new ArrayList<>();
             if (PlayMusic.nowPlayMusic != null) {
                 list.add(PlayMusic.nowPlayMusic.getID());

--- a/core/command/CommandBanPlayer.java
+++ b/core/command/CommandBanPlayer.java
@@ -20,7 +20,7 @@ public class CommandBanPlayer implements ICommand {
 
     @Override
     public List<String> tab(Object player, String name, String[] args, int index) {
-        if (args.length == index || (args.length == index + 1 && args[index].isEmpty())) {
+        if (args.length == index || (args.length == index + 1)) {
             List<String> list = new ArrayList<>();
             for (Object item : AllMusic.side.getPlayers()) {
                 String name1 = AllMusic.side.getPlayerName(item);

--- a/core/command/CommandEX.java
+++ b/core/command/CommandEX.java
@@ -258,7 +258,7 @@ public class CommandEX {
         List<String> arguments = new ArrayList<>();
         if (arg.length == 0) {
             arguments.addAll(normal);
-            if (AllMusic.side.checkPermission(sender)) {
+            if (isAdmin(name) || AllMusic.side.checkPermission(sender)) {
                 arguments.addAll(admin);
             }
             if (AllMusic.getSearch(name) != null) {
@@ -267,7 +267,7 @@ public class CommandEX {
         } else {
             if (arg[0] == null || arg[0].isEmpty() || arg.length == 1) {
                 arguments.addAll(normal);
-                if (AllMusic.side.checkPermission(sender)) {
+                if (isAdmin(name) || AllMusic.side.checkPermission(sender)) {
                     arguments.addAll(admin);
                 }
                 if (arg[0] == null || arg[0].isEmpty()) {
@@ -280,7 +280,7 @@ public class CommandEX {
                 if (command != null) {
                     arguments.addAll(command.tab(sender, name, arg, 1));
                 }
-                if (AllMusic.side.checkPermission(sender)) {
+                if (isAdmin(name) || AllMusic.side.checkPermission(sender)) {
                     command = CommandEX.commandAdminList.get(arg[0]);
                     if (command != null) {
                         arguments.addAll(command.tab(sender, name, arg, 1));

--- a/core/command/CommandEX.java
+++ b/core/command/CommandEX.java
@@ -17,40 +17,6 @@ public class CommandEX {
 
     public static final Map<String, ICommand> commandList = new HashMap<>();
     public static final Map<String, ICommand> commandAdminList = new HashMap<>();
-    private static final List<String> normal = new ArrayList<String>() {{
-        this.add("help");
-        this.add("stop");
-        this.add("cancel");
-        this.add("list");
-        this.add("vote");
-        this.add("mute");
-        this.add("search");
-        this.add("hud");
-        this.add("push");
-    }};
-
-    /**
-     * 管理员的指令
-     */
-    private static final List<String> admin = new ArrayList<String>() {{
-        this.add("reload");
-        this.add("next");
-        this.add("ban");
-        this.add("banplayer");
-        this.add("url");
-        this.add("delete");
-        this.add("addlist");
-        this.add("clearlist");
-        this.add("cookie");
-    }};
-    /**
-     * 搜歌的指令
-     */
-    private static final List<String> search = new ArrayList<String>() {{
-        this.add("select");
-        this.add("nextpage");
-        this.add("lastpage");
-    }};
 
     static {
         commandList.put("stop", new CommandStop());
@@ -81,6 +47,25 @@ public class CommandEX {
         commandAdminList.put("cookie", new CommandCookie());
         commandAdminList.put("test", new CommandTest());
     }
+
+    private static final List<String> normal = new ArrayList<String>() {{
+        this.addAll(commandList.keySet());
+    }};
+
+    /**
+     * 管理员的指令
+     */
+    private static final List<String> admin = new ArrayList<String>() {{
+        this.addAll(commandAdminList.keySet());
+    }};
+    /**
+     * 搜歌的指令
+     */
+    private static final List<String> search = new ArrayList<String>() {{
+        this.add("select");
+        this.add("nextpage");
+        this.add("lastpage");
+    }};
 
     /**
      * 搜索音乐
@@ -289,8 +274,6 @@ public class CommandEX {
                     if (AllMusic.getSearch(name) != null) {
                         return search;
                     }
-                }else {
-                    arguments.addAll(search);
                 }
             } else {
                 ICommand command = CommandEX.commandList.get(arg[0]);

--- a/core/command/CommandEX.java
+++ b/core/command/CommandEX.java
@@ -18,6 +18,7 @@ public class CommandEX {
     public static final Map<String, ICommand> commandList = new HashMap<>();
     public static final Map<String, ICommand> commandAdminList = new HashMap<>();
     private static final List<String> normal = new ArrayList<String>() {{
+        this.add("help");
         this.add("stop");
         this.add("cancel");
         this.add("list");
@@ -35,11 +36,12 @@ public class CommandEX {
         this.add("reload");
         this.add("next");
         this.add("ban");
+        this.add("banplayer");
+        this.add("url");
         this.add("delete");
         this.add("addlist");
         this.add("clearlist");
         this.add("cookie");
-        this.add("test");
     }};
     /**
      * 搜歌的指令
@@ -287,6 +289,8 @@ public class CommandEX {
                     if (AllMusic.getSearch(name) != null) {
                         return search;
                     }
+                }else {
+                    arguments.addAll(search);
                 }
             } else {
                 ICommand command = CommandEX.commandList.get(arg[0]);

--- a/core/command/CommandHelp.java
+++ b/core/command/CommandHelp.java
@@ -55,7 +55,7 @@ public class CommandHelp extends ACommand {
                 AllMusic.getMessage().click.clickCheck, "/music hud pic rotate ");
         AllMusic.side.sendMessageSuggest(sender, AllMusic.getMessage().help.normal.hud5,
                 AllMusic.getMessage().click.clickCheck, "/music hud pic speed ");
-        if (AllMusic.side.checkPermission(name)) {
+        if (AllMusic.side.checkPermission(sender)) {
             AllMusic.side.sendMessageRun(sender, AllMusic.getMessage().help.admin.reload,
                     AllMusic.getMessage().click.clickRun, "/music reload");
             AllMusic.side.sendMessageRun(sender, AllMusic.getMessage().help.admin.next,

--- a/core/command/CommandMute.java
+++ b/core/command/CommandMute.java
@@ -45,7 +45,7 @@ public class CommandMute extends ACommand {
 
     @Override
     public List<String> tab(Object player, String name, String[] args, int index) {
-        if (args.length == index || (args.length == index + 1 && args[index].isEmpty())) {
+        if (args.length == index || (args.length == index + 1 )) {
             return new ArrayList<String>() {{
                 add("list");
             }};

--- a/core/command/CommandSelect.java
+++ b/core/command/CommandSelect.java
@@ -40,12 +40,12 @@ public class CommandSelect extends ACommand {
 
     @Override
     public List<String> tab(Object player, String name, String[] args, int index) {
-        if (args.length == 1 || (args.length == 2 && args[1].isEmpty())) {
+        if (args.length == 1 || (args.length == 2 )) {
             List<String> list = new ArrayList<>();
             SearchPageObj obj = AllMusic.getSearch(name);
             if (obj != null) {
                 for (int a = 0; a < obj.getIndex(); a++) {
-                    list.add(String.valueOf(a));
+                    list.add(String.valueOf(a+1));
                 }
             }
             return list;

--- a/core/command/CommandUnban.java
+++ b/core/command/CommandUnban.java
@@ -24,7 +24,7 @@ public class CommandUnban extends ACommand {
 
     @Override
     public List<String> tab(Object player, String name, String[] args, int index) {
-//        if (args.length == index || (args.length == index + 1 && args[index].isEmpty())) {
+//        if (args.length == index || (args.length == index + 1 )) {
 //            List<String> list = new ArrayList<>();
 //            if (PlayMusic.nowPlayMusic != null) {
 //                list.add(PlayMusic.nowPlayMusic.getID());

--- a/core/command/CommandUnban.java
+++ b/core/command/CommandUnban.java
@@ -24,17 +24,9 @@ public class CommandUnban extends ACommand {
 
     @Override
     public List<String> tab(Object player, String name, String[] args, int index) {
-//        if (args.length == index || (args.length == index + 1 )) {
-//            List<String> list = new ArrayList<>();
-//            if (PlayMusic.nowPlayMusic != null) {
-//                list.add(PlayMusic.nowPlayMusic.getID());
-//            }
-//            for (SongInfoObj item : PlayMusic.getList()) {
-//                list.add(item.getID());
-//            }
-//
-//            return list;
-//        }
+        if (args.length == index || (args.length == index + 1 )) {
+            return DataSql.getBanMusicList();
+        }
 
         return Collections.emptyList();
     }

--- a/core/command/CommandUnban.java
+++ b/core/command/CommandUnban.java
@@ -4,8 +4,10 @@ import com.coloryr.allmusic.server.core.AllMusic;
 import com.coloryr.allmusic.server.core.sql.DataSql;
 import com.coloryr.allmusic.server.core.utils.Function;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CommandUnban extends ACommand {
     @Override
@@ -25,7 +27,7 @@ public class CommandUnban extends ACommand {
     @Override
     public List<String> tab(Object player, String name, String[] args, int index) {
         if (args.length == index || (args.length == index + 1 )) {
-            return DataSql.getBanMusicList();
+            return new ArrayList<>(DataSql.Cache.banMusic);
         }
 
         return Collections.emptyList();

--- a/core/command/CommandUnbanPlayer.java
+++ b/core/command/CommandUnbanPlayer.java
@@ -19,9 +19,9 @@ public class CommandUnbanPlayer implements ICommand {
 
     @Override
     public List<String> tab(Object player, String name, String[] args, int index) {
-//        if (args.length == index || (args.length == index + 1 )) {
-//            return AllMusic.side.getPlayerList();
-//        }
+        if (args.length == index || (args.length == index + 1 )) {
+            return DataSql.getBanPlayerList();
+        }
 
         return Collections.emptyList();
     }

--- a/core/command/CommandUnbanPlayer.java
+++ b/core/command/CommandUnbanPlayer.java
@@ -3,6 +3,7 @@ package com.coloryr.allmusic.server.core.command;
 import com.coloryr.allmusic.server.core.AllMusic;
 import com.coloryr.allmusic.server.core.sql.DataSql;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -20,7 +21,7 @@ public class CommandUnbanPlayer implements ICommand {
     @Override
     public List<String> tab(Object player, String name, String[] args, int index) {
         if (args.length == index || (args.length == index + 1 )) {
-            return DataSql.getBanPlayerList();
+            return new ArrayList<>(DataSql.Cache.banPlayers);
         }
 
         return Collections.emptyList();

--- a/core/command/CommandUnbanPlayer.java
+++ b/core/command/CommandUnbanPlayer.java
@@ -19,7 +19,7 @@ public class CommandUnbanPlayer implements ICommand {
 
     @Override
     public List<String> tab(Object player, String name, String[] args, int index) {
-//        if (args.length == index || (args.length == index + 1 && args[index].isEmpty())) {
+//        if (args.length == index || (args.length == index + 1 )) {
 //            return AllMusic.side.getPlayerList();
 //        }
 

--- a/core/sql/DataSql.java
+++ b/core/sql/DataSql.java
@@ -7,6 +7,7 @@ import com.coloryr.allmusic.server.core.objs.hud.PosObj;
 
 import java.io.File;
 import java.sql.*;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Queue;
@@ -443,7 +444,7 @@ public class DataSql {
     }
 
     /**
-     * 检查玩家是否在数据库
+     * check a music in ban list?
      *
      * @param name 用户名
      * @return 结果
@@ -467,6 +468,34 @@ public class DataSql {
             e.printStackTrace();
         }
         return false;
+    }
+
+
+    /***
+     * a way to get ban music list
+     * @return ban music list
+     */
+    public static List<String> getBanMusicList() {
+        try {
+            List<String> banList = new ArrayList<>();
+            if (connection.isReadOnly() || connection.isClosed()) {
+                init();
+            }
+            Statement stat = connection.createStatement();
+            ResultSet set = stat.executeQuery("SELECT sid FROM allmusic_banlist");
+            while (set.next()) {
+                String musicName = set.getString("sid");
+                if (musicName != null) {
+                    banList.add(musicName);
+                }
+            }
+            set.close();
+            stat.close();
+            return banList;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return new ArrayList<>();
     }
 
     public static void clearBan() {
@@ -543,6 +572,32 @@ public class DataSql {
             e.printStackTrace();
         }
         return false;
+    }
+
+    /***
+     * @return a list of ban players
+     */
+    public static List<String> getBanPlayerList() {
+        try {
+            List<String> banList = new ArrayList<>();
+            if (connection.isReadOnly() || connection.isClosed()) {
+                init();
+            }
+            Statement stat = connection.createStatement();
+            ResultSet set = stat.executeQuery("SELECT sid FROM allmusic_banplayer");
+            while (set.next()) {
+                String playerName = set.getString("sid");
+                if (playerName != null) {
+                    banList.add(playerName);
+                }
+            }
+            set.close();
+            stat.close();
+            return banList;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return new ArrayList<>();
     }
 
     public static void clearBanPlayer() {

--- a/fabric_1_16_5/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
+++ b/fabric_1_16_5/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
@@ -26,11 +26,11 @@ public class CommandFabric implements Command<ServerCommandSource>, Predicate<Se
 
     @Override
     public int run(CommandContext<ServerCommandSource> context) {
-        ServerCommandSource item = context.getSource();
+        var item = context.getSource();
 
-        String input = context.getInput();
-        String[] temp = input.split(" ");
-        String[] arg = new String[temp.length - 1];
+        var input = context.getInput();
+        var temp = input.split(" ");
+        var arg = new String[temp.length - 1];
         System.arraycopy(temp, 1, arg, 0, arg.length);
 
         CommandEX.execute(item, context.getSource().getName(), arg);
@@ -45,20 +45,23 @@ public class CommandFabric implements Command<ServerCommandSource>, Predicate<Se
 
     @Override
     public CompletableFuture<Suggestions> getSuggestions(CommandContext<ServerCommandSource> context, SuggestionsBuilder builder) {
-        ServerCommandSource item = context.getSource();
+        var item = context.getSource();
 
-        String input = context.getInput();
-        String[] temp = input.split(" ");
-        String[] arg = new String[input.endsWith(" ") ? temp.length : temp.length - 1];
+        var input = context.getInput();
+        var temp = input.split(" ");
+        var arg = new String[input.endsWith(" ") ? temp.length : temp.length - 1];
         System.arraycopy(temp, 1, arg, 0, temp.length - 1);
 
-        if (input.endsWith(" "))
-            builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
+        builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
 
         List<String> results = CommandEX.getTabList(item, item.getName(), arg);
 
+        String remaining = builder.getRemaining().trim();
+
         for (String s : results) {
-            builder.suggest(s);
+            if (s.startsWith(remaining)){
+                builder.suggest(s);
+            }
         }
 
         return builder.buildFuture();

--- a/fabric_1_18_2/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
+++ b/fabric_1_18_2/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
@@ -52,13 +52,16 @@ public class CommandFabric implements Command<ServerCommandSource>, Predicate<Se
         var arg = new String[input.endsWith(" ") ? temp.length : temp.length - 1];
         System.arraycopy(temp, 1, arg, 0, temp.length - 1);
 
-        if (input.endsWith(" "))
-            builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
+        builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
 
         List<String> results = CommandEX.getTabList(item, item.getName(), arg);
 
+        String remaining = builder.getRemaining().trim();
+
         for (String s : results) {
-            builder.suggest(s);
+            if (s.startsWith(remaining)){
+                builder.suggest(s);
+            }
         }
 
         return builder.buildFuture();

--- a/fabric_1_19_2/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
+++ b/fabric_1_19_2/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
@@ -52,13 +52,16 @@ public class CommandFabric implements Command<ServerCommandSource>, Predicate<Se
         var arg = new String[input.endsWith(" ") ? temp.length : temp.length - 1];
         System.arraycopy(temp, 1, arg, 0, temp.length - 1);
 
-        if (input.endsWith(" "))
-            builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
+        builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
 
         List<String> results = CommandEX.getTabList(item, item.getName(), arg);
 
+        String remaining = builder.getRemaining().trim();
+
         for (String s : results) {
-            builder.suggest(s);
+            if (s.startsWith(remaining)){
+                builder.suggest(s);
+            }
         }
 
         return builder.buildFuture();

--- a/fabric_1_19_3/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
+++ b/fabric_1_19_3/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
@@ -52,13 +52,16 @@ public class CommandFabric implements Command<ServerCommandSource>, Predicate<Se
         var arg = new String[input.endsWith(" ") ? temp.length : temp.length - 1];
         System.arraycopy(temp, 1, arg, 0, temp.length - 1);
 
-        if (input.endsWith(" "))
-            builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
+        builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
 
         List<String> results = CommandEX.getTabList(item, item.getName(), arg);
 
+        String remaining = builder.getRemaining().trim();
+
         for (String s : results) {
-            builder.suggest(s);
+            if (s.startsWith(remaining)){
+                builder.suggest(s);
+            }
         }
 
         return builder.buildFuture();

--- a/fabric_1_20/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
+++ b/fabric_1_20/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
@@ -52,13 +52,16 @@ public class CommandFabric implements Command<ServerCommandSource>, Predicate<Se
         var arg = new String[input.endsWith(" ") ? temp.length : temp.length - 1];
         System.arraycopy(temp, 1, arg, 0, temp.length - 1);
 
-        if (input.endsWith(" "))
-            builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
+        builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
 
         List<String> results = CommandEX.getTabList(item, item.getName(), arg);
 
+        String remaining = builder.getRemaining().trim();
+
         for (String s : results) {
-            builder.suggest(s);
+            if (s.startsWith(remaining)){
+                builder.suggest(s);
+            }
         }
 
         return builder.buildFuture();

--- a/fabric_1_20_2/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
+++ b/fabric_1_20_2/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
@@ -52,13 +52,16 @@ public class CommandFabric implements Command<ServerCommandSource>, Predicate<Se
         var arg = new String[input.endsWith(" ") ? temp.length : temp.length - 1];
         System.arraycopy(temp, 1, arg, 0, temp.length - 1);
 
-        if (input.endsWith(" "))
-            builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
+        builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
 
         List<String> results = CommandEX.getTabList(item, item.getName(), arg);
 
+        String remaining = builder.getRemaining().trim();
+
         for (String s : results) {
-            builder.suggest(s);
+            if (s.startsWith(remaining)){
+                builder.suggest(s);
+            }
         }
 
         return builder.buildFuture();

--- a/fabric_1_20_6/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
+++ b/fabric_1_20_6/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
@@ -52,13 +52,16 @@ public class CommandFabric implements Command<ServerCommandSource>, Predicate<Se
         var arg = new String[input.endsWith(" ") ? temp.length : temp.length - 1];
         System.arraycopy(temp, 1, arg, 0, temp.length - 1);
 
-        if (input.endsWith(" "))
-            builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
+        builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
 
         List<String> results = CommandEX.getTabList(item, item.getName(), arg);
 
+        String remaining = builder.getRemaining().trim();
+
         for (String s : results) {
-            builder.suggest(s);
+            if (s.startsWith(remaining)){
+                builder.suggest(s);
+            }
         }
 
         return builder.buildFuture();

--- a/fabric_1_21/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
+++ b/fabric_1_21/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
@@ -52,13 +52,16 @@ public class CommandFabric implements Command<ServerCommandSource>, Predicate<Se
         var arg = new String[input.endsWith(" ") ? temp.length : temp.length - 1];
         System.arraycopy(temp, 1, arg, 0, temp.length - 1);
 
-        if (input.endsWith(" "))
-            builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
+        builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
 
         List<String> results = CommandEX.getTabList(item, item.getName(), arg);
 
+        String remaining = builder.getRemaining().trim();
+
         for (String s : results) {
-            builder.suggest(s);
+            if (s.startsWith(remaining)){
+                builder.suggest(s);
+            }
         }
 
         return builder.buildFuture();

--- a/fabric_1_21_4/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
+++ b/fabric_1_21_4/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
@@ -52,13 +52,16 @@ public class CommandFabric implements Command<ServerCommandSource>, Predicate<Se
         var arg = new String[input.endsWith(" ") ? temp.length : temp.length - 1];
         System.arraycopy(temp, 1, arg, 0, temp.length - 1);
 
-        if (input.endsWith(" "))
-            builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
+        builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
 
         List<String> results = CommandEX.getTabList(item, item.getName(), arg);
 
+        String remaining = builder.getRemaining().trim();
+
         for (String s : results) {
-            builder.suggest(s);
+            if (s.startsWith(remaining)){
+                builder.suggest(s);
+            }
         }
 
         return builder.buildFuture();

--- a/fabric_1_21_5/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
+++ b/fabric_1_21_5/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
@@ -52,13 +52,16 @@ public class CommandFabric implements Command<ServerCommandSource>, Predicate<Se
         var arg = new String[input.endsWith(" ") ? temp.length : temp.length - 1];
         System.arraycopy(temp, 1, arg, 0, temp.length - 1);
 
-        if (input.endsWith(" "))
-            builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
+        builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
 
         List<String> results = CommandEX.getTabList(item, item.getName(), arg);
 
+        String remaining = builder.getRemaining().trim();
+
         for (String s : results) {
-            builder.suggest(s);
+            if (s.startsWith(remaining)){
+                builder.suggest(s);
+            }
         }
 
         return builder.buildFuture();

--- a/fabric_1_21_6/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
+++ b/fabric_1_21_6/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
@@ -52,8 +52,7 @@ public class CommandFabric implements Command<ServerCommandSource>, Predicate<Se
         var arg = new String[input.endsWith(" ") ? temp.length : temp.length - 1];
         System.arraycopy(temp, 1, arg, 0, temp.length - 1);
 
-        if (input.endsWith(" "))
-            builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
+        builder = builder.createOffset(builder.getInput().lastIndexOf(32) + 1);
 
         List<String> results = CommandEX.getTabList(item, item.getName(), arg);
 

--- a/fabric_1_21_6/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
+++ b/fabric_1_21_6/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
@@ -11,7 +11,6 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;

--- a/fabric_1_21_6/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
+++ b/fabric_1_21_6/src/main/java/com/coloryr/allmusic/server/side/fabric/CommandFabric.java
@@ -11,6 +11,7 @@ import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
@@ -56,8 +57,12 @@ public class CommandFabric implements Command<ServerCommandSource>, Predicate<Se
 
         List<String> results = CommandEX.getTabList(item, item.getName(), arg);
 
+        String remaining = builder.getRemaining().trim();
+
         for (String s : results) {
-            builder.suggest(s);
+            if (s.startsWith(remaining)){
+                builder.suggest(s);
+            }
         }
 
         return builder.buildFuture();

--- a/server_top/src/main/java/com/coloryr/allmusic/server/side/velocity/CommandVelocity.java
+++ b/server_top/src/main/java/com/coloryr/allmusic/server/side/velocity/CommandVelocity.java
@@ -7,6 +7,7 @@ import com.velocitypowered.api.command.SimpleCommand;
 import com.velocitypowered.api.proxy.Player;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CommandVelocity implements SimpleCommand {
     @Override
@@ -32,6 +33,12 @@ public class CommandVelocity implements SimpleCommand {
         if (invocation.source() instanceof Player) {
             Player player = (Player) invocation.source();
             String name = player.getUsername();
+            if (args.length > 0 && args[args.length - 1] != null){
+                String r = args[args.length - 1].trim();
+                return CommandEX.getTabList(player,name,args).stream()
+                        .filter(s -> s.startsWith(r))
+                        .collect(Collectors.toList());
+            }
             return CommandEX.getTabList(player, name, args);
         }
         return ImmutableList.of();


### PR DESCRIPTION
1. 修复命令建议的偏移问题（移除一条if）
2. 修复一些指令的tab函数中的npe问题，并且使其补全正常化（移除冗余的isEmpty()判断）
3. 改进unban系列指令的命令补全
4. 修正javadoc中的错误
5. 修正一部分指令不会被建议的问题
6. 修复在fabric side时checkpermission的错误用法
7. 修复在某些环境下配置中的管理员无法正确获得关于管理员指令的建议
8. 修正velocity环境下补全行为异于原版的问题