### PR TITLE
fix: 修复 KTV 模式长歌词错位[AI]

### DIFF
--- a/client/fabric_1_16_5/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/fabric_1_16_5/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -285,7 +285,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (TextItem item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/fabric_1_20_1/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/fabric_1_20_1/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -283,7 +283,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (var item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/fabric_1_21/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/fabric_1_21/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -195,7 +195,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (var item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/fabric_1_21_11/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/fabric_1_21_11/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -202,7 +202,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (var item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/fabric_1_21_6/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/fabric_1_21_6/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -196,7 +196,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (var item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/fabric_26_1/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/fabric_26_1/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -204,7 +204,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (var item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/fabric_26_2/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/fabric_26_2/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -191,7 +191,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (var item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/forge_1_12_2/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/forge_1_12_2/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -190,7 +190,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (TextItem item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/forge_1_16_5/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/forge_1_16_5/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -285,7 +285,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (TextItem item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/forge_1_20_1/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/forge_1_20_1/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -283,7 +283,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (var item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/neoforge_1_21/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/neoforge_1_21/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -282,7 +282,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (var item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/neoforge_1_21_11/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/neoforge_1_21_11/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -203,7 +203,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (var item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/neoforge_1_21_6/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/neoforge_1_21_6/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -196,7 +196,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (var item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/neoforge_26_1/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/neoforge_26_1/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -204,7 +204,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (var item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/neoforge_26_2/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/neoforge_26_2/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -192,7 +192,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
         for (var item : texts) {
             Point2f point = AllMusicHud.getPos(Math.min(maxWidth, item.textWidth), item.textHeight, x, y, dir);
 
-            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, offsetX % item.textWidth, item.scale);
+            drawLoop(alpha, point.x, point.y + item.y, 0, item.y, item.textWidth, item.textHeight, maxWidth, getOffset(item) % item.textWidth, item.scale);
         }
     }
 

--- a/client/src/main/java/com/coloryr/allmusic/client/core/AllMusicHud.java
+++ b/client/src/main/java/com/coloryr/allmusic/client/core/AllMusicHud.java
@@ -76,6 +76,7 @@ public class AllMusicHud {
     private HudPosObj save;
     private float lyricState = 0.0f;
     private long lyricTime = -1;
+    private int lyricWidth;
     private int pgOffset;
     private float picScale;
     private BufferedImage bg2;
@@ -235,6 +236,24 @@ public class AllMusicHud {
         if (save == null || ktv == null || lyricTime == -1) return;
         lyricTime += 10;
         kUpdate();
+        updateKtvOffset();
+    }
+
+    private void updateKtvOffset() {
+        if (ktv == null || save == null || lyricWidth <= 0) {
+            lyricRender.clearKtvOffset();
+            lyricKtvRender.clearKtvOffset();
+            return;
+        }
+
+        float offset = 0;
+        int maxWidth = save.lyric.maxWidth;
+        if (maxWidth > 0 && lyricWidth > maxWidth) {
+            offset = (lyricWidth - maxWidth) * lyricState;
+        }
+
+        lyricRender.setKtvOffset(offset);
+        lyricKtvRender.setKtvOffset(offset);
     }
 
     private void loopTick() {
@@ -508,6 +527,8 @@ public class AllMusicHud {
                     allWidth = Math.max(allWidth, AllMusicCore.bridge.getTextWidth(item));
                 }
 
+                lyricWidth = allWidth;
+
                 lyricKtvRender.resize(allWidth, allHeight);
                 lyricKtvRender.use();
                 for (String item : temp) {
@@ -519,6 +540,7 @@ public class AllMusicHud {
                 }
                 lyricKtvRender.unUse();
             } else {
+                lyricWidth = 0;
                 lyricKtvRender.clear();
             }
 
@@ -612,6 +634,10 @@ public class AllMusicHud {
     public void setKtv(long time, KtvLyricObj pack2) {
         ktv = pack2;
         lyricTime = time;
+        if (pack2 == null) {
+            lyricRender.clearKtvOffset();
+            lyricKtvRender.clearKtvOffset();
+        }
     }
 
     public void setTime(long time, long now) {

--- a/client/src/main/java/com/coloryr/allmusic/client/core/render/TextFrameBuffer.java
+++ b/client/src/main/java/com/coloryr/allmusic/client/core/render/TextFrameBuffer.java
@@ -11,6 +11,10 @@ public abstract class TextFrameBuffer {
     protected int nowWidth, nowHeight;
     protected long offsetX;
     protected boolean isDraw;
+    /**
+     * KTV模式下的强制滚动偏移，>=0 时优先使用
+     */
+    protected float ktvOffset = -1;
 
     // 最大公约数（GCD）
     public static long gcd(long a, long b) {
@@ -57,6 +61,30 @@ public abstract class TextFrameBuffer {
         if (offsetX > temp) {
             offsetX = 0;
         }
+    }
+
+    /**
+     * 设置KTV模式下的强制滚动偏移
+     */
+    public void setKtvOffset(float offset) {
+        this.ktvOffset = offset;
+    }
+
+    /**
+     * 清除KTV模式下的强制滚动偏移，恢复默认滚动
+     */
+    public void clearKtvOffset() {
+        this.ktvOffset = -1;
+    }
+
+    /**
+     * 获取当前应使用的水平滚动偏移
+     */
+    protected float getOffset(TextItem item) {
+        if (ktvOffset >= 0) {
+            return ktvOffset;
+        }
+        return offsetX % item.textWidth;
     }
 
     public static class TextItem {


### PR DESCRIPTION
修复 KTV 模式下歌词仅高亮层滚动，底层不滚动导致的错位
<img width="605" height="80" alt="ShareX_20260620_4y0vp" src="https://github.com/user-attachments/assets/f66d0aca-245f-495d-8a4d-f7b4010fb248" />
<img width="793" height="167" alt="ShareX_20260620_aUMOP" src="https://github.com/user-attachments/assets/23a7571f-cbcf-4091-86a2-7998bd74af9e" />
