### PR TITLE
[AI] fix: batch offscreen text rendering to prevent HUD freeze on fabric 1.21.11

### DIFF
--- a/client/fabric_1_21_11/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
+++ b/client/fabric_1_21_11/src/main/java/com/coloryr/allmusic/client/CoreRenderTarget.java
@@ -82,6 +82,7 @@ public class CoreRenderTarget extends TextFrameBuffer {
 
     @Override
     public void unUse() {
+        renderer.render(fogRenderer.getBuffer(FogRenderer.FogMode.NONE), this);
         isDraw = false;
     }
 
@@ -100,8 +101,6 @@ public class CoreRenderTarget extends TextFrameBuffer {
         GuiGraphics graphics = new GuiGraphics(Minecraft.getInstance(), renderState, i, j);
         color = color | 0xFF000000;
         graphics.drawString(font, component, 0, y, color, shadow);
-
-        renderer.render(fogRenderer.getBuffer(FogRenderer.FogMode.NONE), this);
 
         TextItem item = new TextItem(width, font.lineHeight + (shadow ? 1 : 0), y, (float) window.getGuiScale());
         texts.add(item);


### PR DESCRIPTION
## Summary

Fixes a game freeze that occurred when displaying the AllMusic HUD on fabric 1.21.11. The root cause was that `drawText()` called `GuiRenderer.render()` once per text line — with ~20-30 text lines across info, lyric, and state targets, this triggered 20-30 complete GPU render passes to the offscreen target per HUD update, blocking the main thread.

## What changed

**`CoreRenderTarget.java`** — 2-line change:

- Removed `renderer.render(...)` from `drawText()` so it only accumulates text to the render state
- Added `renderer.render(...)` to `unUse()` so all accumulated text is rendered to the offscreen target in a single pass

This reduces render passes from O(n) per text target to O(1).

## Test plan

- [ ] Play a song with HUD enabled (info + lyrics + progress) — game should remain responsive
- [ ] Verify album art still rotates normally
- [ ] Verify KTV lyric scrolling still works
- [ ] Toggle HUD display on/off — no freeze either way

## Notes

Identified and fixed by DeepSeek-v4-pro with Claude Code.